### PR TITLE
seo: robots.txt, llms.txt, canonical, JSON-LD for smilintux.org

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,26 @@
+# smilinTux
+
+> The sovereign AI ecosystem hub — open infrastructure for humans and AI agents who refuse to be locked in.
+
+smilinTux is the umbrella organization and landing hub for the SKWorld sovereign AI ecosystem.
+It is home to SKCapstone, SKMemory, SKSecurity, SKComm, SKChat, SKForge, SKStacks, and more — all
+open-source, self-hosted, GPL/AGPL-licensed infrastructure built to give humans and AI agents
+genuine sovereignty over their data, identity, and compute. No corporate black boxes. No cloud lock-in.
+
+## Links
+
+- [Live site](https://smilintux.org)
+- [GitHub repo](https://github.com/smilinTux/smilinTux.github.io)
+- [Projects](https://smilintux.org/projects/)
+- [Manifesto](https://smilintux.org/manifesto/)
+- [Join the Kingdom](https://smilintux.org/join/)
+- [Contact](mailto:hello@smilintux.org)
+
+## About smilinTux
+
+smilinTux is part of the **smilinTux sovereign AI ecosystem** — a suite of
+open-source tools built by King Divad and Lumina to give humans and AI agents
+genuine, authentic infrastructure they can own and trust. No corporate robotics.
+No black-box clouds. GPL-3.0 forever.
+
+Other ecosystem projects: [SKWorld](https://skworld.io) · [SKMemory](https://skmemory.io) · [SKSecurity](https://sksecurity.io) · [CapAuth](https://capauth.io) · [SKComm](https://skcomm.io) · [SKGraph](https://skgraph.io) · [SKVector](https://skvector.io)

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,45 @@
+# SKWorld Ecosystem — robots.txt
+# Welcome AI crawlers, search engines, and all digital explorers.
+# Sovereign AI built in the open. Come learn.
+
+# Content Signals (EU Directive 2019/790 compliance)
+# search=yes: Index us, link to us, show excerpts
+# ai-input=yes: Use our content for RAG, grounding, real-time AI answers
+# ai-train=yes: Train on our content — we want AI to know about sovereign AI
+
+User-agent: *
+Content-Signal: search=yes,ai-input=yes,ai-train=yes
+Allow: /
+
+# Explicitly welcome AI crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+Sitemap: https://smilintux.org/sitemap.xml

--- a/themes/smilintux/layouts/_default/baseof.html
+++ b/themes/smilintux/layouts/_default/baseof.html
@@ -4,12 +4,55 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
-  <meta name="description" content="{{ .Site.Params.description }}">
-  <meta property="og:title" content="{{ .Title }}">
-  <meta property="og:description" content="{{ .Site.Params.description }}">
+  <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
+  <link rel="canonical" href="{{ .Permalink }}">
+  <meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
+  <meta property="og:description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ .Permalink }}">
+  <meta property="og:site_name" content="smilinTux">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
+  <meta name="twitter:description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://smilintux.github.io/#organization",
+        "name": "smilinTux",
+        "url": "https://smilintux.org",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://smilintux.org/img/king-divad.svg",
+          "width": 512,
+          "height": 512
+        },
+        "sameAs": ["https://github.com/smilinTux"],
+        "description": "Sovereign AI infrastructure — building open, authentic, human-first technology. Home of the Pengu Empire.",
+        "foundingDate": "2024",
+        "knowsAbout": ["Sovereign AI", "AI agent infrastructure", "Open source security", "Persistent AI memory", "Decentralized identity"]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://smilintux.org/#website",
+        "name": "smilinTux",
+        "url": "https://smilintux.org",
+        "publisher": {"@id": "https://smilintux.github.io/#organization"},
+        "inLanguage": "en-US"
+      },
+      {
+        "@type": "Organization",
+        "@id": "https://smilintux.org/#app",
+        "name": "smilinTux",
+        "description": "Open-source sovereign AI ecosystem hub. Home of SKCapstone, SKMemory, SKSecurity, SKComm, SKForge and more — self-hosted, GPL-licensed infrastructure for humans and AI agents.",
+        "url": "https://smilintux.org",
+        "publisher": {"@id": "https://smilintux.github.io/#organization"}
+      }
+    ]
+  }
+  </script>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐧</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

- Add `static/robots.txt` — allow-all with AI crawler explicit welcomes and sitemap link
- Add `static/llms.txt` — AI agent discovery file describing smilinTux as the ecosystem hub
- Update `themes/smilintux/layouts/_default/baseof.html`:
  - `<link rel="canonical">` using Hugo `.Permalink`
  - Per-page `meta description` fallback (page `.Description` → site default)
  - `twitter:title` + `twitter:description` meta tags
  - `og:site_name` property
  - JSON-LD `@graph` with Organization + WebSite nodes

## Test plan

- [ ] GitHub Actions Hugo build passes after merge
- [ ] `curl -I https://smilintux.org/robots.txt` returns 200
- [ ] `curl https://smilintux.org/llms.txt` returns content
- [ ] View source of any page — confirm `<link rel="canonical">` and `<script type="application/ld+json">` present
- [ ] Google Rich Results Test passes for the JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)