### PR TITLE
feat: Own the Full Vertical — smilinTux as the home of the sovereign vertical

### DIFF
--- a/themes/smilintux/layouts/_default/baseof.html
+++ b/themes/smilintux/layouts/_default/baseof.html
@@ -126,6 +126,85 @@
     .section h2 { font-size: 2rem; margin-bottom: 1rem; }
     .section p { color: var(--gray); margin-bottom: 1rem; }
 
+    /* Own the Full Vertical */
+    .own-vertical {
+      max-width: 900px; margin: 0 auto; padding: 3rem 2rem;
+    }
+    .own-vertical-inner {
+      background: linear-gradient(135deg,
+        rgba(0,200,212,.07) 0%,
+        rgba(255,209,102,.06) 50%,
+        rgba(0,200,212,.04) 100%);
+      border: 1px solid rgba(0,200,212,.2);
+      border-radius: 16px;
+      padding: 2.5rem 2rem;
+      text-align: center;
+    }
+    .own-vertical-kicker {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.75rem; letter-spacing: 0.16em;
+      text-transform: uppercase; color: var(--accent);
+      display: block; margin-bottom: 1rem;
+    }
+    .own-vertical h2 {
+      font-size: clamp(1.6rem, 3vw, 2.2rem);
+      line-height: 1.2; color: var(--white);
+      margin-bottom: 1rem;
+    }
+    .own-vertical h2 .accent { color: var(--accent); }
+    .own-vertical h2 .yellow { color: var(--yellow); }
+    .own-vertical-manifesto {
+      color: var(--gray); font-size: 1rem; line-height: 1.75;
+      max-width: 640px; margin: 0 auto 1rem;
+    }
+    .own-vertical-manifesto strong { color: var(--white); }
+    .own-vertical-sovereignty {
+      color: rgba(169,178,187,.6); font-size: 0.85rem;
+      margin-bottom: 1.75rem; font-style: italic;
+    }
+    .own-vertical-sovereignty strong { color: var(--gray); font-style: normal; }
+    .own-vertical-pillars {
+      display: flex; flex-wrap: wrap; gap: 0.6rem;
+      justify-content: center; margin-bottom: 1.75rem;
+    }
+    .pillar-tag {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(0,200,212,.2);
+      border-radius: 20px; padding: 0.35rem 0.9rem;
+      font-size: 0.8rem; color: var(--gray);
+      text-decoration: none; transition: all 0.2s;
+    }
+    .pillar-tag:hover {
+      border-color: var(--accent); color: var(--accent);
+      background: rgba(0,200,212,.06); opacity: 1;
+    }
+    .own-vertical-ctas {
+      display: flex; justify-content: center; gap: 0.75rem; flex-wrap: wrap;
+    }
+    .btn-vertical-primary {
+      display: inline-flex; align-items: center;
+      padding: 0.7rem 1.5rem;
+      background: var(--accent); color: var(--black);
+      font-weight: 700; font-size: 0.9rem;
+      border-radius: 8px; text-decoration: none;
+      transition: opacity 0.15s;
+    }
+    .btn-vertical-primary:hover { opacity: 0.85; }
+    .btn-vertical-outline {
+      display: inline-flex; align-items: center;
+      padding: 0.7rem 1.5rem;
+      background: transparent;
+      border: 1px solid rgba(0,200,212,.35); color: var(--accent);
+      font-weight: 600; font-size: 0.9rem;
+      border-radius: 8px; text-decoration: none;
+      transition: all 0.15s;
+    }
+    .btn-vertical-outline:hover {
+      border-color: var(--accent);
+      background: rgba(0,200,212,.07); opacity: 1;
+    }
+
     /* Footer */
     footer {
       text-align: center; padding: 3rem 2rem; border-top: 1px solid rgba(255,255,255,0.1);

--- a/themes/smilintux/layouts/index.html
+++ b/themes/smilintux/layouts/index.html
@@ -38,6 +38,42 @@
   <p><strong>Your infrastructure. Your data. Your software.</strong></p>
 </section>
 
+<section class="own-vertical" id="vertical" aria-labelledby="vertical-heading">
+  <div class="own-vertical-inner">
+    <span class="own-vertical-kicker">Own the Full Vertical</span>
+    <h2 id="vertical-heading">
+      From <span class="accent">silicon</span> to <span class="yellow">soul</span> —<br>
+      smilinTux is the home of the sovereign vertical.
+    </h2>
+    <p class="own-vertical-manifesto">
+      The modern stack is rented. Your data lives on someone else's disk, behind someone else's key,
+      served by a model that phones home. You don't own it — you <em>visit</em> it.
+      <strong>We rebuilt it from the ground up.</strong> Own the full vertical — silicon, OS, identity,
+      data, models, security, comms, apps, soul. Every layer open. Every layer swappable. Every layer <strong>yours</strong>.
+    </p>
+    <p class="own-vertical-sovereignty">
+      <strong>Your data never leaves. Your keys never leave.</strong>
+      No cloud you don't control, no model that calls home, no lock-in you can't walk away from.
+      Sovereignty isn't a feature — it's the foundation.
+    </p>
+    <!-- The vertical as layer links -->
+    <div class="own-vertical-pillars" role="list" aria-label="The sovereign vertical stack">
+      <a href="https://souls.skworld.io" class="pillar-tag" role="listitem">🎭 Soul</a>
+      <a href="https://skforge.io" class="pillar-tag" role="listitem">⚒️ Apps</a>
+      <a href="https://skcomm.io" class="pillar-tag" role="listitem">💬 Comms</a>
+      <a href="https://skmemory.io" class="pillar-tag" role="listitem">🧠 Data</a>
+      <a href="https://capauth.io" class="pillar-tag" role="listitem">🔐 Identity</a>
+      <a href="https://sksecurity.io" class="pillar-tag" role="listitem">🛡️ Security</a>
+      <a href="https://skos.skworld.io" class="pillar-tag" role="listitem">🐧 OS (skos)</a>
+      <a href="#" class="pillar-tag" role="listitem" style="color:rgba(169,178,187,.45);border-color:rgba(255,255,255,.08);">⚡ Silicon (yours)</a>
+    </div>
+    <div class="own-vertical-ctas">
+      <a href="https://skworld.io" class="btn-vertical-primary">🌍 See the whole vertical</a>
+      <a href="https://skos.skworld.io" class="btn-vertical-outline">🐧 skos — the keystone OS</a>
+    </div>
+  </div>
+</section>
+
 <section class="section">
   <h2>👑 About smilinTux</h2>
   <p><strong>smilinTux</strong> is an open-source organization dedicated to building sovereign infrastructure that actually doesn't suck.</p>


### PR DESCRIPTION
## Summary

- Adds **\"Own the Full Vertical\"** manifesto section to the Hugo homepage layout (`themes/smilintux/layouts/index.html`)
- Positions smilinTux as the **home of the sovereign vertical** — the org that builds every layer from silicon to soul
- Includes the full manifesto (tightened), data-sovereignty line, silicon→soul layer-link pills, and CTAs to `skworld.io` + `skos.skworld.io`
- All new CSS added to `themes/smilintux/layouts/_default/baseof.html` — uses existing CSS variable tokens (`--accent`, `--yellow`, `--white`, `--gray`) and brand fonts (Inter, Fira Code)
- Hugo build: section inserted between "Why Self-Host?" and "About smilinTux" — no existing sections removed or altered

## Theme alignment (per spec)

- smilinTux position: the org hub that is home to the sovereign vertical
- Full manifesto included (hub treatment) ✓
- Data-sovereignty line ✓
- Ecosystem cross-links as "layers you own" ✓
- CTAs: skworld.io (whole vertical) + skos.skworld.io (the keystone) ✓
- CSS reuses teal/yellow brand tokens — no foreign styles

## Test plan

- [ ] GitHub Action build passes (Hugo renders without error)
- [ ] New section appears between "Why Self-Host?" and "About smilinTux"
- [ ] Layer pill links are correct (souls.skworld.io, skforge.io, skcomm.io, etc.)
- [ ] "See the whole vertical" → https://skworld.io
- [ ] "skos — the keystone OS" → https://skos.skworld.io
- [ ] Existing projects grid, hero, about section unchanged
- [ ] Mobile: section wraps cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)